### PR TITLE
Make errorMessage helper return null for bodies that are not plain text.

### DIFF
--- a/logging/src/main/java/com/nightlynexus/retrofit/logging/LoggingCallAdapterFactory.java
+++ b/logging/src/main/java/com/nightlynexus/retrofit/logging/LoggingCallAdapterFactory.java
@@ -38,8 +38,8 @@ public final class LoggingCallAdapterFactory extends CallAdapter.Factory {
   }
 
   /**
-   * Reads a {@link ResponseBody} as a string. This is useful for logging error bodies. Consumes the
-   * {@code errorBody}.
+   * Reads a {@link ResponseBody} as a string or {@code null} if the error message is not plain
+   * text. This is useful for logging error bodies. Consumes the {@code errorBody}.
    */
   public static String errorMessage(ResponseBody errorBody) throws IOException {
     if (errorBody.contentLength() == 0) {
@@ -48,8 +48,9 @@ public final class LoggingCallAdapterFactory extends CallAdapter.Factory {
     Buffer buffer = new Buffer();
     buffer.writeAll(errorBody.source());
     if (!isPlaintext(buffer)) {
-      return "Error body is not plain text.";
+      return null;
     }
+    // ResponseBody reads the BOM (if it exists) for us.
     return ResponseBody.create(buffer, errorBody.contentType(), buffer.size()).string();
   }
 

--- a/logging/src/test/java/com/nightlynexus/retrofit/logging/LoggingCallAdapterFactoryTest.java
+++ b/logging/src/test/java/com/nightlynexus/retrofit/logging/LoggingCallAdapterFactoryTest.java
@@ -43,8 +43,7 @@ public final class LoggingCallAdapterFactoryTest {
 
   @Test public void errorMessageHelperChecksForPlainText() throws IOException {
     ResponseBody errorBody = ResponseBody.create(String.valueOf((char) 0x9F), null);
-    assertThat(LoggingCallAdapterFactory.errorMessage(errorBody))
-        .isEqualTo("Error body is not plain text.");
+    assertThat(LoggingCallAdapterFactory.errorMessage(errorBody)).isNull();
   }
 
   private interface Service {


### PR DESCRIPTION
This lets loggers set their own messages.